### PR TITLE
Added the timestamp at Event insertion when building the PriorityQueue in PriorityLock.

### DIFF
--- a/test_threads.py
+++ b/test_threads.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+import time
+
+from threads import Thread, PriorityLock
+
+
+############################################################
+# MISC
+############################################################
+
+def test_thread(lock, priority):
+    lock.acquire(priority)
+    try:
+        print("Hello from priority: %s" % str(priority))
+        time.sleep(5)
+    finally:
+        lock.release()
+    print("Finished priority: %s" % str(priority))
+
+
+############################################################
+# MAIN
+############################################################
+
+if __name__ == "__main__":
+    lock = PriorityLock()
+    threads = Thread()
+    for pos in reversed(range(0, 100)):
+        threads.start(test_thread, args=[lock, pos], track=True)
+    print("Started first batch of threads")
+    time.sleep(15)
+    for pos in reversed(range(0, 100)):
+        threads.start(test_thread, args=[lock, pos], track=True)
+    print("Started second batch of threads")
+    threads.join()
+    print("All threads finished")

--- a/threads.py
+++ b/threads.py
@@ -33,7 +33,7 @@ class PriorityLock:
         self._mutex.acquire()
         # Notify the next thread in line, if any.
         try:
-            _, event = self._waiter_queue.get_nowait()
+            _, timeAdded, event = self._waiter_queue.get_nowait()
         except queue.Empty:
             self._is_available = True
         else:

--- a/threads.py
+++ b/threads.py
@@ -6,6 +6,7 @@ except ImportError:
     import Queue as queue
 import copy
 import threading
+import datetime
 
 
 class PriorityLock:
@@ -22,7 +23,7 @@ class PriorityLock:
             self._mutex.release()
             return True
         event = threading.Event()
-        self._waiter_queue.put((priority, event))
+        self._waiter_queue.put((priority, datetime.datetime.now(), event))
         self._mutex.release()
         event.wait()
         # When the event is triggered, we have the lock.


### PR DESCRIPTION
Adding the timestamp adds an extra layer of sorting that in my testing allows the PriorityQueue to properly sort the entries without needing to compare Event objects. Perhaps it's a workaround rather than a true fix, but I think the true fix would be implementing __lt__ and __gt__ in the Event class. Another possible workaround suggested in the Python3 threading documentation is to wrap the Event class and priority in a class that would ignore the encapsulated Event class when compared in PriorityQueue.